### PR TITLE
Fix stray comment in auth service

### DIFF
--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -20,7 +20,7 @@ export class AuthService {
   /** Cache in memoria del profilo utente */
   profile$: Observable<UserProfile>;
 
-  //Ruolo corrente, inizialmente letto da localStorage */
+  //Ruolo corrente, inizialmente letto da localStorage
   private _role$ = new BehaviorSubject<string | null>(
     localStorage.getItem('role')
   );


### PR DESCRIPTION
## Summary
- clean up stray comment terminator in `auth.service.ts`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684566b84918832fbdfae2fedc743f64