### PR TITLE
Add weekly agenda page

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -56,6 +56,15 @@ const routes: Routes = [
         (m) => m.TicketConfigPageModule
       ),
   },
+  {
+    path: 'agenda',
+    loadChildren: () =>
+      import('./pages/agenda/agenda.module').then((m) => m.AgendaPageModule),
+    canActivate: [AuthGuardService],
+    data: {
+      roles: ['admin', 'segreteria'],
+    },
+  },
 ];
 
 @NgModule({

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -28,6 +28,12 @@
             <ion-label class="section-title">Modifica Ticket</ion-label>
           </ion-item>
         </ion-menu-toggle>
+        <ion-menu-toggle auto-hide="false">
+          <ion-item routerLink="/agenda" detail="false">
+            <ion-icon slot="start" name="calendar-outline" class="icon"></ion-icon>
+            <ion-label class="section-title">Agenda</ion-label>
+          </ion-item>
+        </ion-menu-toggle>
       </ion-list>
     </ion-content>
   </ion-menu>

--- a/src/app/pages/agenda/agenda-routing.module.ts
+++ b/src/app/pages/agenda/agenda-routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+import { AgendaPage } from './agenda.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: AgendaPage,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class AgendaPageRoutingModule {}

--- a/src/app/pages/agenda/agenda.module.ts
+++ b/src/app/pages/agenda/agenda.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { IonicModule } from '@ionic/angular';
+import { AgendaPageRoutingModule } from './agenda-routing.module';
+import { AgendaPage } from './agenda.page';
+import { EditPatientModalModule } from '../../edit-patient-modal/edit-patient-modal.module';
+
+@NgModule({
+  imports: [CommonModule, FormsModule, IonicModule, AgendaPageRoutingModule, EditPatientModalModule],
+  declarations: [AgendaPage],
+})
+export class AgendaPageModule {}

--- a/src/app/pages/agenda/agenda.page.html
+++ b/src/app/pages/agenda/agenda.page.html
@@ -1,0 +1,27 @@
+<ion-header>
+  <ion-toolbar color="primary">
+    <ion-buttons slot="start">
+      <ion-button fill="clear" (click)="openAppMenu()">
+        <ion-icon name="menu-outline"></ion-icon>
+      </ion-button>
+    </ion-buttons>
+    <ion-title>Agenda Settimanale</ion-title>
+    <ion-buttons slot="end">
+      <ion-button fill="clear" (click)="addAvailability()">
+        <ion-icon name="add-circle-outline"></ion-icon>
+      </ion-button>
+    </ion-buttons>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content class="calendar-content">
+  <div class="calendar-grid">
+    <div class="day-column" *ngFor="let day of weekDays">
+      <div class="day-header">{{ day | date:'EEEE dd/MM' }}</div>
+      <div class="event" *ngFor="let ev of eventsByDay[day | date:'yyyy-MM-dd']" [style.background]="ev.color" (click)="openEdit(ev.patient)">
+        <div class="time">{{ ev.patient.appointment_time | date:'HH:mm' }}</div>
+        <div class="name">{{ ev.patient.full_name }}</div>
+      </div>
+    </div>
+  </div>
+</ion-content>

--- a/src/app/pages/agenda/agenda.page.scss
+++ b/src/app/pages/agenda/agenda.page.scss
@@ -1,0 +1,25 @@
+.calendar-content {
+  --background: #f5f7fa;
+}
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 0.5rem;
+  padding: 0.5rem;
+}
+.day-header {
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+  color: var(--ion-color-primary);
+}
+.event {
+  padding: 0.25rem;
+  margin-bottom: 0.25rem;
+  border-radius: 4px;
+  color: #fff;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+.time {
+  font-weight: bold;
+}

--- a/src/app/pages/agenda/agenda.page.spec.ts
+++ b/src/app/pages/agenda/agenda.page.spec.ts
@@ -1,0 +1,17 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AgendaPage } from './agenda.page';
+
+describe('AgendaPage', () => {
+  let component: AgendaPage;
+  let fixture: ComponentFixture<AgendaPage>;
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AgendaPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/agenda/agenda.page.ts
+++ b/src/app/pages/agenda/agenda.page.ts
@@ -1,0 +1,121 @@
+import { Component, OnInit } from '@angular/core';
+import { AlertController, ModalController } from '@ionic/angular';
+import { PatientService, Patient } from '../../services/patient.service';
+import { DoctorService, Doctor } from '../../services/doctor.service';
+import { AvailabilityService, DoctorAvailability } from '../../services/availability.service';
+import { Observable, combineLatest, map } from 'rxjs';
+import { EditPatientModalComponent } from '../../edit-patient-modal/edit-patient-modal.component';
+import { MenuController } from '@ionic/angular';
+
+interface CalendarEvent {
+  patient: Patient;
+  doctor?: Doctor;
+  color: string;
+}
+
+@Component({
+  selector: 'app-agenda',
+  templateUrl: './agenda.page.html',
+  styleUrls: ['./agenda.page.scss'],
+  standalone: false,
+})
+export class AgendaPage implements OnInit {
+  weekDays: Date[] = [];
+  eventsByDay: Record<string, CalendarEvent[]> = {};
+  colorMap = new Map<string, string>();
+
+  constructor(
+    private patientService: PatientService,
+    private doctorService: DoctorService,
+    private modalCtrl: ModalController,
+    private alertCtrl: AlertController,
+    private availabilityService: AvailabilityService,
+    private menuCtrl: MenuController
+  ) {}
+
+  ngOnInit() {
+    this.initWeek();
+    combineLatest([this.patientService.patients$, this.doctorService.doctors$])
+      .pipe(
+        map(([patients, doctors]) => {
+          const colors = [
+            '#5e92f3',
+            '#f48fb1',
+            '#aed581',
+            '#ffb74d',
+            '#4dd0e1',
+            '#ba68c8',
+          ];
+          this.colorMap.clear();
+          doctors.forEach((d, i) => this.colorMap.set(d.id, colors[i % colors.length]));
+          const mapEvents: Record<string, CalendarEvent[]> = {};
+          patients.forEach((p) => {
+            const date = p.appointment_time.split('T')[0];
+            const doctor = doctors.find((d) => d.study === p.assigned_study);
+            const color = doctor ? this.colorMap.get(doctor.id)! : '#ccc';
+            const ev: CalendarEvent = { patient: p, doctor, color };
+            if (!mapEvents[date]) mapEvents[date] = [];
+            mapEvents[date].push(ev);
+          });
+          return mapEvents;
+        })
+      )
+      .subscribe((mapEvents) => {
+        this.eventsByDay = mapEvents;
+      });
+  }
+
+  initWeek() {
+    const now = new Date();
+    const day = now.getDay();
+    const diff = now.getDate() - day + (day === 0 ? -6 : 1); // adjust when day is sunday
+    const monday = new Date(now.setDate(diff));
+    this.weekDays = Array.from({ length: 7 }, (_, i) => {
+      const d = new Date(monday);
+      d.setDate(monday.getDate() + i);
+      return d;
+    });
+  }
+
+  async openEdit(patient: Patient) {
+    const modal = await this.modalCtrl.create({
+      component: EditPatientModalComponent,
+      cssClass: 'custom-modal',
+      componentProps: { patientData: patient },
+    });
+    await modal.present();
+  }
+
+  async addAvailability() {
+    const alert = await this.alertCtrl.create({
+      header: 'Aggiungi disponibilità',
+      inputs: [
+        { name: 'doctor', type: 'text', placeholder: 'Medico' },
+        { name: 'day', type: 'text', placeholder: 'Giorno' },
+        { name: 'start', type: 'time', placeholder: 'Inizio' },
+        { name: 'end', type: 'time', placeholder: 'Fine' },
+      ],
+      buttons: [
+        { text: 'Annulla', role: 'cancel' },
+        {
+          text: 'Salva',
+          handler: (data) => {
+            if (data.doctor && data.day && data.start && data.end) {
+              this.availabilityService.addAvailability({
+                doctor: data.doctor,
+                day: data.day,
+                start: data.start,
+                end: data.end,
+              });
+            }
+          },
+        },
+      ],
+    });
+    await alert.present();
+  }
+
+  openAppMenu() {
+    this.menuCtrl.open('segreteria-menu');
+  }
+}

--- a/src/app/services/availability.service.ts
+++ b/src/app/services/availability.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+export interface DoctorAvailability {
+  doctor: string;
+  day: string;
+  start: string;
+  end: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class AvailabilityService {
+  private _availabilities$ = new BehaviorSubject<DoctorAvailability[]>([]);
+  availabilities$ = this._availabilities$.asObservable();
+
+  addAvailability(av: DoctorAvailability) {
+    const list = [...this._availabilities$.value, av];
+    this._availabilities$.next(list);
+  }
+}


### PR DESCRIPTION
## Summary
- add agenda page with routing and module
- implement weekly calendar view with editable appointments
- include new menu entry for Agenda
- provide service to store doctor availability

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68737b21feac832f8f9afb5e64de3c00